### PR TITLE
Fix: NLP 라이브러리 soynlp->python-mecab-ko로 변경

### DIFF
--- a/src/main/model.py
+++ b/src/main/model.py
@@ -61,6 +61,7 @@ def get_clothes_recommend():
 @blue_model.route('/schedule', methods=['GET'])
 def region_model():
     title = request.args.get('title')
+    region = request.args.get('region')
     
     Token = schedule_Tokenizer()
     sample = [Token(title)]
@@ -82,7 +83,7 @@ def region_model():
     plan = clf.predict(sample)
     
     Token = region_Tokenizer()
-    sample2 = [Token(title)]
+    sample2 = [Token(region)]
     
     vectorizer = joblib.load(region_vector_path)
     sample2 = vectorizer.transform(sample2)


### PR DESCRIPTION
## 📕 제목
- #10 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 작업내용1: NLP 라이브러리 soynlp->python-mecab-ko로 변경
=> soynlp는 사용자가 학습을 시켜야 함. 데이터셋의 문제로 학습 후 한국어 조사 인식을 못한다.
따라서 명사 분류 기능이 있는 python-mecab-ko로 변경하기로 결정
- [x] 작업내용2: 일정 API에 region 파라미터를 다시 추가
=> 모델의 확실한 성능을 위해 필수로 받는 파라미터로 설정